### PR TITLE
fix Customize FP

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -900,3 +900,23 @@ SecRule REQUEST_FILENAME "@endsWith /wp-json/aioseo/v1/wizard" \
     nolog,\
     ctl:ruleRemoveTargetById=930120;ARGS_NAMES,\
     ver:'wordpress-rule-exclusions-plugin/1.0.1'"
+
+
+#
+# [ Appearance ]
+#
+
+# Accessing WordPress (Appearance --> Customize) gives FP at PL 1
+# FP: "Invalid date" value in _wpCustomizeControlsL10n array in customize-controls script
+# This activates rule 953100 which looks for "Invalid date" pattern in php-errors.data
+# Tested with the latest CRS rules from default branch with tag - v4.0.0-rc1
+SecRule REQUEST_FILENAME "@beginsWith /wp-admin/customize.php" \
+     "id:9507980,\
+     phase:4,\
+     pass,\
+     t:none,\
+     nolog,\
+     ver:'wordpress-rule-exclusions-plugin/1.0.1'\
+     chain"
+     SecRule RESPONSE_BODY "@pm (Invalid date)" \
+          "ctl:ruleRemoveById=953100"

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -883,7 +883,20 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
 
 SecMarker "END-WORDPRESS-ADMIN"
 
-
+# Fix FP preventing access to plugins|plugin-install pages
+# Tested with the CRS rules from default branch with tag - v4.0.0-rc1
+SecRule REQUEST_FILENAME "@rx /wp-admin/(?:plugins|plugin-install).php" \
+     "id:9507951,\
+     phase:4,\
+     pass,\
+     t:none,\
+     nolog,\
+     ver:'wordpress-rule-exclusions-plugin/1.0.1'\
+     chain"
+     SecRule RESPONSE_BODY "@pm 'The function'" \
+          "ctl:ruleRemoveById=953100"
+          
+          
 #
 # [ Plugins ]
 #

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -245,6 +245,18 @@ SecRule ARGS:wp_customize "@streq on" \
             ctl:ruleRemoveTargetById=942460;ARGS:partials"
 
 
+# Accessing WordPress (Appearance --> Customize) gives FP at PL 1
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/customize.php" \
+     "id:9507161,\
+     phase:4,\
+     pass,\
+     t:none,\
+     nolog,\
+     ver:'wordpress-rule-exclusions-plugin/1.0.1'\
+     chain"
+     SecRule RESPONSE_BODY "@rx (?i)Invalid date" \
+          "ctl:ruleRemoveById=953100"
+
 
 # Self calls to wp-cron.php?doing_wp_cron=[timestamp]
 # These requests may be missing Accept, Content-Length headers.
@@ -866,6 +878,18 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetById=932120;ARGS:plugin,\
             ctl:ruleRemoveTargetById=932120;ARGS:slug"
 
+# Fix FP preventing access to plugins|plugin-install pages
+SecRule REQUEST_FILENAME "@rx /wp-admin/(?:plugins|plugin-install)\.php$" \
+     "id:9507951,\
+     phase:4,\
+     pass,\
+     t:none,\
+     nolog,\
+     ver:'wordpress-rule-exclusions-plugin/1.0.1'\
+     chain"
+     SecRule RESPONSE_BODY "@rx (?i)The function" \
+          "ctl:ruleRemoveById=953100"
+
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     "id:9507970,\
     phase:2,\
@@ -883,18 +907,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
 
 SecMarker "END-WORDPRESS-ADMIN"
 
-# Fix FP preventing access to plugins|plugin-install pages
-# Tested with the CRS rules from default branch with tag - v4.0.0-rc1
-SecRule REQUEST_FILENAME "@rx /wp-admin/(?:plugins|plugin-install).php" \
-     "id:9507951,\
-     phase:4,\
-     pass,\
-     t:none,\
-     nolog,\
-     ver:'wordpress-rule-exclusions-plugin/1.0.1'\
-     chain"
-     SecRule RESPONSE_BODY "@pm 'The function'" \
-          "ctl:ruleRemoveById=953100"
+
           
           
 #
@@ -914,22 +927,3 @@ SecRule REQUEST_FILENAME "@endsWith /wp-json/aioseo/v1/wizard" \
     ctl:ruleRemoveTargetById=930120;ARGS_NAMES,\
     ver:'wordpress-rule-exclusions-plugin/1.0.1'"
 
-
-#
-# [ Appearance ]
-#
-
-# Accessing WordPress (Appearance --> Customize) gives FP at PL 1
-# FP: "Invalid date" value in _wpCustomizeControlsL10n array in customize-controls script
-# This activates rule 953100 which looks for "Invalid date" pattern in php-errors.data
-# Tested with the latest CRS rules from default branch with tag - v4.0.0-rc1
-SecRule REQUEST_FILENAME "@beginsWith /wp-admin/customize.php" \
-     "id:9507980,\
-     phase:4,\
-     pass,\
-     t:none,\
-     nolog,\
-     ver:'wordpress-rule-exclusions-plugin/1.0.1'\
-     chain"
-     SecRule RESPONSE_BODY "@pm (Invalid date)" \
-          "ctl:ruleRemoveById=953100"


### PR DESCRIPTION
Fix FP when accessing Appearance --> Customize

``
[Sun Jan 22 20:09:21.678298 2023] [:error] [pid 98465] [client 127.0.0.1:47742] [client 127.0.0.1] ModSecurity: Warning. Matched phrase "Invalid date" at RESPONSE_BODY. [file "/etc/modsecurity/coreruleset/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf"] [line "44"] [id "953100"] [msg "PHP Information Leakage"] [data "Matched Data: Invalid date found within RESPONSE_BODY"] [severity "ERROR"] [ver "OWASP_CRS/4.0.0-rc1"] [tag "application-multi"] [tag "language-php"] [tag "platform-multi"] [tag "attack-disclosure"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/118/116"] [tag "PCI/6.5.6"] [hostname "localhost"] [uri "/wp-admin/customize.php"] [unique_id "Y81KmcLafCHEUhbW65fuYAAAAAA"], referer: https://localhost/wp-admin/
``