### PR TITLE
fix FP when trying to update a page

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -177,7 +177,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
             ctl:ruleRemoveById=200002,\
             ctl:ruleRemoveById=200004"
 
-# Gutenbery when trying to update a page
+# Gutenbery when trying to update a post/page
 SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)/" \
 "id:9507144,\
   phase:1,\
@@ -499,6 +499,18 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:excerpt,\
             ctl:ruleRemoveById=920272,\
             ctl:ruleRemoveById=921180"
+            
+# Edit posts
+# /wp-admin/post.php accessing a post
+SecRule REQUEST_URI "@beginsWith /wp-admin/post.php" \
+     "id:9507701,\
+     phase:4,\
+     pass,\
+     t:none,\
+     nolog,\
+     chain"
+     SecRule RESPONSE_BODY "move_uploaded_file" \
+          "ctl:ruleRemoveById=953110"
 
 # Autosave posts and pages
 # ARGS_NAMES:data[wp-check-locked-posts][] can appear multiple times

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -178,7 +178,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
             ctl:ruleRemoveById=200004"
 
 # Gutenbery when trying to update a page
-SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/pages/" \
+SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)/" \
 "id:9507144,\
   phase:1,\
   nolog,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -177,6 +177,16 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
             ctl:ruleRemoveById=200002,\
             ctl:ruleRemoveById=200004"
 
+# Gutenbery when trying to update a page
+SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/pages/" \
+"id:9507144,\
+  phase:1,\
+  nolog,\
+  pass,\
+  t:none,\
+  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method/ /x-method-override/'"
+
+
 #
 # [ Live preview ]
 # Used when an administrator customizes the site and previews the result

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -184,6 +184,7 @@ SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages|users)" \
   nolog,\
   pass,\
   t:none,\
+  ver:'wordpress-rule-exclusions-plugin/1.0.1',\
   setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method/ /x-method-override/'"
 
 

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -178,7 +178,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
             ctl:ruleRemoveById=200004"
 
 # Gutenbery when trying to update a post/page
-SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)" \
+SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages|users)" \
 "id:9507144,\
   phase:1,\
   nolog,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -178,7 +178,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
             ctl:ruleRemoveById=200004"
 
 # Gutenbery when trying to update a post/page
-SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)/" \
+SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)" \
 "id:9507144,\
   phase:1,\
   nolog,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -500,17 +500,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
             ctl:ruleRemoveById=920272,\
             ctl:ruleRemoveById=921180"
             
-# Edit posts
-# /wp-admin/post.php accessing a post
-SecRule REQUEST_URI "@beginsWith /wp-admin/post.php" \
-     "id:9507701,\
-     phase:4,\
-     pass,\
-     t:none,\
-     nolog,\
-     chain"
-     SecRule RESPONSE_BODY "move_uploaded_file" \
-          "ctl:ruleRemoveById=953110"
 
 # Autosave posts and pages
 # ARGS_NAMES:data[wp-check-locked-posts][] can appear multiple times


### PR DESCRIPTION
``[Sat Mar 11 19:17:21.667279 2023] [:error] [pid 307003] [client 103.80.153.172:34666] [client 103.80.153.172] ModSecurity: Warning. String match within "/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/" at TX:header_name_x-http-method-override. [file "/etc/modsecurity/coreruleset/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1156"] [id "920450"] [msg "HTTP header is restricted by policy (/x-http-method-override/)"] [data "Restricted header detected: /x-http-method-override/"] [severity "CRITICAL"] [ver "OWASP_CRS/4.0.0-rc1"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [tag "PCI/12.1"] [hostname "blog.jitendrapatro.me"] [uri "/wp-json/wp/v2/pages/433"] [unique_id "ZAyGadfHqbffM75p0nOlBAAAAAA"], referer: https://blog.jitendrapatro.me/wp-admin/post.php?post=433&action=edit``



Some request headers are recently added based on [this blog post](https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it). The `x-http-method-override` header prevents updating a WordPress page at PL 1. I can't even update my own Homepage due to this.