### PR TITLE
Fix false positive when adding a link to github/twitter/medium/tiktok etc profile

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,7 @@
 # Contributors to WordPress Rule Exclusions Plugin
 
 - [agusmu](https://github.com/agusmu)
+- [Esad Cetiner](https://github.com/esadcetiner)
 - [Christian Folini](https://github.com/dune73)
 - [Ervin Hegedus](https://github.com/airween)
 - [Walter Hop](https://github.com/lifeforms)

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -372,6 +372,15 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:youtube,\
             ctl:ruleRemoveTargetById=931130;ARGS:wikipedia,\
             ctl:ruleRemoveTargetById=931130;ARGS:github,\
+            ctl:ruleRemoveTargetById=931130;ARGS:tiktok,\
+            ctl:ruleRemoveTargetById=931130;ARGS:vkontakte,\
+            ctl:ruleRemoveTargetById=931130;ARGS:medium,\
+            ctl:ruleRemoveTargetById=931130;ARGS:twitter,\
+            ctl:ruleRemoveTargetById=931130;ARGS:tsf-user-meta[facebook_page],\
+            ctl:ruleRemoveTargetById=931130;ARGS:odnoklassniki,\
+            ctl:ruleRemoveTargetById=931130;ARGS:vimeo,\
+            ctl:ruleRemoveTargetById=931130;ARGS:dribbble,\
+            ctl:ruleRemoveTargetById=931130;ARGS:wordpress,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:first_name,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -371,6 +371,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:tumblr,\
             ctl:ruleRemoveTargetById=931130;ARGS:youtube,\
             ctl:ruleRemoveTargetById=931130;ARGS:wikipedia,\
+            ctl:ruleRemoveTargetById=931130;ARGS:github,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:first_name,\


### PR DESCRIPTION
RFI is triggered when you try to link to your github profile inside ``wp-admin/profile.php``