### PR TITLE
Fix false positive when modifying other users profiles

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -362,6 +362,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
             ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
             ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
             ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
@@ -381,7 +382,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:vimeo,\
             ctl:ruleRemoveTargetById=931130;ARGS:dribbble,\
             ctl:ruleRemoveTargetById=931130;ARGS:wordpress,\
-            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:first_name,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:last_name,\
@@ -404,6 +404,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
             ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
             ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
             ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
@@ -423,7 +424,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:vimeo,\
             ctl:ruleRemoveTargetById=931130;ARGS:dribbble,\
             ctl:ruleRemoveTargetById=931130;ARGS:wordpress,\
-            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:first_name,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:last_name,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -404,7 +404,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
-            ctl:ruleRemoveTargetById=931130;ARGS:url,\
             ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
             ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
             ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
@@ -414,6 +413,20 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:tumblr,\
             ctl:ruleRemoveTargetById=931130;ARGS:youtube,\
             ctl:ruleRemoveTargetById=931130;ARGS:wikipedia,\
+            ctl:ruleRemoveTargetById=931130;ARGS:github,\
+            ctl:ruleRemoveTargetById=931130;ARGS:tiktok,\
+            ctl:ruleRemoveTargetById=931130;ARGS:vkontakte,\
+            ctl:ruleRemoveTargetById=931130;ARGS:medium,\
+            ctl:ruleRemoveTargetById=931130;ARGS:twitter,\
+            ctl:ruleRemoveTargetById=931130;ARGS:tsf-user-meta[facebook_page],\
+            ctl:ruleRemoveTargetById=931130;ARGS:odnoklassniki,\
+            ctl:ruleRemoveTargetById=931130;ARGS:vimeo,\
+            ctl:ruleRemoveTargetById=931130;ARGS:dribbble,\
+            ctl:ruleRemoveTargetById=931130;ARGS:wordpress,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:first_name,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:last_name,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"


### PR DESCRIPTION
This PR is similar to https://github.com/coreruleset/wordpress-rule-exclusions-plugin/pull/12, it fixes a few additonal false positives under ``/wp-admin/user-edit.php``.
I noticed that ``/wp-admin/user-edit.php`` page is identical to ``/wp-admin/profile.php`` and is missing a few exclusions, I've copied the missing exclusion from 9507520 and pasted it to 9507530.