### PR TITLE
fix: FP while uploading an image

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -728,6 +728,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/async-upload.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
+            ctl:ruleRemoveTargetById=933210;ARGS:name,\
             ctl:ruleRemoveTargetById=942100;ARGS:name"
 
 

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -728,6 +728,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/async-upload.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
+            ctl:ruleRemoveTargetById=920120;FILES:async-upload,\
             ctl:ruleRemoveTargetById=933210;ARGS:name,\
             ctl:ruleRemoveTargetById=942100;ARGS:name"
 

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set Plugin
-# Copyright (c) 2021-2022 Core Rule Set project. All rights reserved.
+# Copyright (c) 2021-2023 Core Rule Set project. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set plugins are distributed under
 # Apache Software License (ASL) version 2
@@ -11,7 +11,7 @@
 # Plugin name: wordpress-rule-exclusions
 # Plugin description:
 # Rule ID block base: 9,507,000 - 9,507,999
-# Plugin version: 1.0.0
+# Plugin version: 1.0.1
 
 # Documentation can be found here:
 # https://github.com/coreruleset/wordpress-rule-exclusions-plugin
@@ -713,6 +713,22 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-xss;ARGS:description"
+
+# Upload media
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/async-upload.php" \
+    "id:9507790,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'wordpress-rule-exclusions-plugin/1.0.1',\
+    chain"
+    SecRule ARGS:action "@streq upload-attachment" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:action "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=942100;ARGS:name"
 
 
 #


### PR DESCRIPTION
Examples of file name which causes FP:
933210: `Vectro_for_Fanuc_CRX_System_(square)_(Custom).jpg`
942100: `2-izb-byt-Zilina-Nad-sadom-(obyvacka).jpg`