### PR TITLE
Fix FP with gutenberg and new installation setup

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -806,15 +806,18 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
 # Wordpress Site Health
 # The wordpress site health page makes use of embedded SQL/PHP
 # which triggers PHP/SQL leak rules.
-SecRule REQUEST_FILENAME "@rx /wp-admin/site-health.php" \
+SecRule REQUEST_FILENAME "@rx /wp-admin/site-health\.php$" \
     "id:9507840,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveById=951220,\
-    ctl:ruleRemoveById=953110,\
-    ver:'wordpress-rule-exclusions-plugin/1.0.1'"
+    ver:'wordpress-rule-exclusions-plugin/1.0.1',\
+    chain"
+    SecRule REQUEST_METHOD "@streq GET" \
+        "t:none,\
+        ctl:ruleRemoveById=951220,\
+        ctl:ruleRemoveById=953110"
 
 #
 # [ Helpers ]

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -79,14 +79,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:url,\
-    ver:'wordpress-rule-exclusions-plugin/1.0.1'"
-
-SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
-    "id:9507180,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:author,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:comment,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:email,\
@@ -361,8 +353,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
 # [ User management ]
 #
 
-# Edit logged-in user
-SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
+# Modifying a user's profile
+SecRule REQUEST_FILENAME "@rx /wp-admin/(?:profile|user-edit)\.php$" \
     "id:9507520,\
     phase:2,\
     pass,\
@@ -376,7 +368,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
-            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
             ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
             ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
             ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
@@ -396,48 +387,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:vimeo,\
             ctl:ruleRemoveTargetById=931130;ARGS:dribbble,\
             ctl:ruleRemoveTargetById=931130;ARGS:wordpress,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:first_name,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:last_name,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
-
-# Edit user
-SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
-    "id:9507530,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'wordpress-rule-exclusions-plugin/1.0.1',\
-    chain"
-    SecRule ARGS:action "@streq update" \
-        "t:none,\
-        chain"
-        SecRule &ARGS:action "@eq 1" \
-            "t:none,\
-            ctl:ruleRemoveTargetById=931130;ARGS:url,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:url,\
-            ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
-            ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
-            ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
-            ctl:ruleRemoveTargetById=931130;ARGS:myspace,\
-            ctl:ruleRemoveTargetById=931130;ARGS:pinterest,\
-            ctl:ruleRemoveTargetById=931130;ARGS:soundcloud,\
-            ctl:ruleRemoveTargetById=931130;ARGS:tumblr,\
-            ctl:ruleRemoveTargetById=931130;ARGS:youtube,\
-            ctl:ruleRemoveTargetById=931130;ARGS:wikipedia,\
-            ctl:ruleRemoveTargetById=931130;ARGS:github,\
-            ctl:ruleRemoveTargetById=931130;ARGS:tiktok,\
-            ctl:ruleRemoveTargetById=931130;ARGS:vkontakte,\
-            ctl:ruleRemoveTargetById=931130;ARGS:medium,\
-            ctl:ruleRemoveTargetById=931130;ARGS:twitter,\
-            ctl:ruleRemoveTargetById=931130;ARGS:tsf-user-meta[facebook_page],\
-            ctl:ruleRemoveTargetById=931130;ARGS:odnoklassniki,\
-            ctl:ruleRemoveTargetById=931130;ARGS:vimeo,\
-            ctl:ruleRemoveTargetById=931130;ARGS:dribbble,\
-            ctl:ruleRemoveTargetById=931130;ARGS:wordpress,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:first_name,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:last_name,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -322,6 +322,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/setup-config.php" \
         chain"
         SecRule &ARGS:step "@eq 1" \
             "t:none,\
+            ctl:ruleRemoveTargetById=932260;ARGS_NAMES:uname,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd"
 
 # WordPress installation: exclude admin password

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -87,7 +87,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=931130;ARGS:url,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:author,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:comment,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:email,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -177,6 +177,19 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
             ctl:ruleRemoveById=200002,\
             ctl:ruleRemoveById=200004"
 
+# Editing a page/post with gutenberg editor
+SecRule REQUEST_FILENAME "@endsWith /index.php" \
+    "id:9507144,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'wordpress-rule-exclusions-plugin/1.0.1',\
+    chain"
+    SecRule REQUEST_HEADERS:x-http-method-override "@streq PUT" \
+        "t:none,\
+        ctl:ruleRemoveById=920450"
+
 #
 # [ Live preview ]
 # Used when an administrator customizes the site and previews the result
@@ -850,6 +863,7 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=921180,\
+    ctl:ruleRemoveTargetById=920100;REQUEST_LINE,\
     ctl:ruleRemoveTargetById=920273;ARGS_NAMES:load[],\
     ctl:ruleRemoveTargetById=942432;ARGS_NAMES:load[],\
     ctl:ruleRemoveTargetById=942360;ARGS:load[],\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -66,6 +66,15 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
+# User Login
+SecRule REQUEST_FILENAME "@streq /wp-admin/admin-ajax.php" \
+    "id:9507121,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd,\
+    ver:'wordpress-rule-exclusions-plugin/1.0.1'"
 
 #
 # [ Comments ]


### PR DESCRIPTION
Fixes FPs when setting up a new wordpress server, when opening a page/post inside the gutenberg editor and removed a few duplicate rules.