### PR TITLE
fix: exclude json.styles from SQL injection detection

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -190,6 +190,17 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
         "t:none,\
         ctl:ruleRemoveById=920450"
 
+# Gutenberg full site editor (v6.3.1+).
+# Requests can contain CSS data, which are detected by libinjection.
+SecRule ARGS_GET "@rx /wp/v[0-9]/global-styles/" \
+    "id:9507145,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=942100;ARGS,\
+    ver:'wordpress-rule-exclusions-plugin/1.0.0'"
+
 #
 # [ Live preview ]
 # Used when an administrator customizes the site and previews the result

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -192,14 +192,23 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
 
 # Gutenberg full site editor (v6.3.1+).
 # Requests can contain CSS data, which are detected by libinjection.
-SecRule ARGS_GET "@rx /wp/v[0-9]/global-styles/" \
+# Uses an additional chain rule to prevent evasion by supplying another
+# argument with the same name.
+SecRule REQUEST_FILENAME "@endsWith /index.php" \
     "id:9507145,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=942100;ARGS,\
-    ver:'wordpress-rule-exclusions-plugin/1.0.0'"
+    ver:'wordpress-rule-exclusions-plugin/1.0.1',\
+    chain"
+    SecRule &ARGS:rest_route "@eq 1" \
+        "t:none,\
+        nolog,\
+        chain"
+        SecRule ARGS:rest_route "@rx ^/wp/v[0-9]+/global-styles/[0-9]+$" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=942100;ARGS"
 
 #
 # [ Live preview ]

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507145.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507145.yaml
@@ -1,0 +1,26 @@
+---
+meta:
+  author: "Max Leske"
+  description: "Wordpress Rule Exclusions Plugin"
+  enabled: true
+  name: 9507145.yaml
+tests:
+  - test_title: 9507145-1
+    desc: Disable SQL injection checks for full site editor
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
+            port: 80
+            method: POST
+            uri: /index.php?rest_route=%2Fwp%2Fv2%2Fglobal-styles%2F50&_locale=user
+            # stripped down version of the full payload
+            data: |
+              {"id":50,"styles":{"blocks":{"core/comment-author-name":{"elements":{"link":{":active":{"color":{"text":"var(--wp--preset--color--tertiary)"}}}}}},"color":{"gradient":"var(--wp--preset--gradient--dots)"},"elements":{"button":{":active":{"color":{"background":"var(--wp--preset--color--secondary)","gradient":"none"}},":focus":{"color":{"gradient":"var(--wp--preset--gradient--secondary-primary)"}},":hover":{"color":{"gradient":"var(--wp--preset--gradient--secondary-primary)"}},":visited":{"color":{"text":"var(--wp--preset--color--base)"}},"border":{"radius":"5px"},"color":{"gradient":"var(--wp--preset--gradient--primary-secondary)","text":"var(--wp--preset--color--base)"}}}},"settings":{"color":{"duotone":{"theme":[{"colors":["#222828","#9EF9FD"],"slug":"default-filter","name":"Default filter"}]}}}}
+          output:
+            no_log_contains: id "942100"


### PR DESCRIPTION
The full site editor (Gutenberg) sends style information in a JSON document. CSS style switches are detected by libinjection as SQL comments.

This commit create a new rule (and associated test) that removes the `json.styles` argument from detection by rule 942100.

Fixes #16