### PR TITLE
rule 9507900 - exclude load chunks for rule 942431 on requests for `/wp-admin/load-...`

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -863,6 +863,8 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     ctl:ruleRemoveTargetById=942430;ARGS:load[chunk_0],\
     ctl:ruleRemoveTargetById=942430;ARGS:load[chunk_1],\
     ctl:ruleRemoveTargetById=942431;ARGS:load[],\
+    ctl:ruleRemoveTargetById=942431;ARGS:load[chunk_0],\
+    ctl:ruleRemoveTargetById=942431;ARGS:load[chunk_1],\
     ctl:ruleRemoveTargetById=942432;ARGS:load[],\
     ver:'wordpress-rule-exclusions-plugin/1.0.1'"
 


### PR DESCRIPTION
Example request : `/wp-admin/load-styles.php?c=1&dir=ltr&load%5Bchunk_0%5D=dashicons,admin-bar,wp-pointer,site-health,common,forms,admin-menu,dashboard,list-tables,edit,revisions,media,themes,about,nav-m&load%5Bchunk_1%5D=enus,widgets,site-icon,l10n,buttons,wp-auth-check,wp-jquery-ui-dialog&ver=5.9.8`