### PR TITLE
fix: SecAction can't be disabled via ctl action

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 This plugin contains rule exclusions for [WordPress](https://wordpress.org/),
-a content management system (CMS), so it can be run flawlessly togather with
+a content management system (CMS), so it can be run flawlessly together with
 OWASP ModSecurity Core Rule Set (CRS).
 
 ## Installation

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -462,7 +462,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
 #
 
 # _wp_http_referer and wp_http_referer are passed on a lot of wp-admin pages
-SecRule REQUEST_FILENAME "@beginsWith /" \
+SecRule REQUEST_FILENAME "@unconditionalMatch" \
     "id:9507600,\
     phase:2,\
     pass,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -462,7 +462,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
 #
 
 # _wp_http_referer and wp_http_referer are passed on a lot of wp-admin pages
-SecAction \
+SecRule REQUEST_FILENAME "@beginsWith /" \
     "id:9507600,\
     phase:2,\
     pass,\


### PR DESCRIPTION
SecAction rules can't be disabled via a ctl action or run time rule exclusion
This can be problematic in reverse proxy deployments where you only want to enable the WordPress plugin for your WordPress domain.
This PR fixes that by replacing the SecAction with a SecRule that's functionally the exact same, except now it can be disabled via a ctl action.