### PR TITLE
feat: Fixing FP on plugins page

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -982,7 +982,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newcontent"
 
 # Opening the plugins page
-# Exclusion of rule 951240 together with test 9507971-4 can be remove after we drop
+# Exclusion of rule 951240 together with test 9507971-4 can be removed after we drop
 # support for CRS 3.
 SecRule REQUEST_FILENAME "@rx /wp-admin/(?:plugins|plugin-install)\.php$" \
     "id:9507971,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -982,8 +982,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newcontent"
 
 # Opening the plugins page
-# The plugin page contains the text "Plugins extend and expand the functionality of WordPress.
-# 953101 is matching "the function"
 SecRule REQUEST_FILENAME "@rx /wp-admin/(?:plugins|plugin-install)\.php$" \
     "id:9507971,\
     phase:4,\
@@ -991,11 +989,9 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/(?:plugins|plugin-install)\.php$" \
     t:none,\
     nolog,\
     ver:'wordpress-rule-exclusions-plugin/1.0.1',\
-    chain"
-    SecRule RESPONSE_BODY "@contains plugins extend and expand the functionality of wordpress." \
-        "t:none,\
-        t:lowercase,\
-        ctl:ruleRemoveById=953101"
+    ctl:ruleRemoveTargetById=951240;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=953101;RESPONSE_BODY"
 
 SecMarker "END-WORDPRESS-ADMIN"
 

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -984,7 +984,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
 # Opening the plugins page
 SecRule REQUEST_FILENAME "@rx /wp-admin/(?:plugins|plugin-install)\.php$" \
     "id:9507971,\
-    phase:4,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -982,6 +982,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newcontent"
 
 # Opening the plugins page
+# Exclusion of rule 951240 together with test 9507971-4 can be remove after we drop
+# support for CRS 3.
 SecRule REQUEST_FILENAME "@rx /wp-admin/(?:plugins|plugin-install)\.php$" \
     "id:9507971,\
     phase:1,\

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507971.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507971.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Esad Cetiner"
+  author: "Esad Cetiner, azurit"
   description: "Wordpress Rule Exclusions Plugin"
   enabled: true
   name: 9507971.yaml
@@ -37,3 +37,35 @@ tests:
             data: "plugins extend and expand the functionality of wordpress"
           output:
             no_log_contains: id "953101"
+  - test_title: 9507971-3
+    desc: Disable 953100
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: GET
+            uri: /wp-admin/plugin-install.php
+            data: "Fixed: Call to a member function get_meta() on null error on WooCommerce order received page"
+          output:
+            no_log_contains: id "953100"
+  - test_title: 9507971-4
+    desc: Disable 951240
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: GET
+            uri: /wp-admin/plugin-install.php
+            data: "warnings</p>\x0a<p>=1.9=<br />\x0a* [Added] Donation link because I&#8217;m poor<br />\x0a* [Removed] errors and deprecating warnings</p>\x0a<p>=1.8.1=<br />\x0a* [Updated] Renamed function from ‚my_profile_update‘ to ‚apg_profile_update‘"
+          output:
+            no_log_contains: id "951240"


### PR DESCRIPTION
Plugin descriptions contains lots of data (like changelogs, error messages and so on) that triggers our response body rules.