### PR TITLE
chore: remove rule exclusion for not supported aio-seo

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -1121,22 +1121,3 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetById=942360;ARGS:s"
 
 SecMarker "END-WORDPRESS-ADMIN"
-
-
-
-#
-# [ Plugins ]
-#
-
-# Plugin slug: aioseo
-# Plugin URL: https://wordpress.org/plugins/all-in-one-seo-pack/
-# FP: ARGS_NAMES:json.wizard.additionalInformation.social.profiles.sameUsername.included.array_2
-# This hits on '.profile', a protected file name.
-SecRule REQUEST_FILENAME "@endsWith /wp-json/aioseo/v1/wizard" \
-    "id:9507960,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ctl:ruleRemoveTargetById=930120;ARGS_NAMES,\
-    ver:'wordpress-rule-exclusions-plugin/1.0.1'"


### PR DESCRIPTION
A rule exclusion for AIO-SEO is included with the plugin even though we don't support plugins, this PR removes that rule exclusion.