### PR TITLE
fix: fp with editing a post after clicking on `filter`

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -452,6 +452,8 @@ SecRule REQUEST_COOKIES:_wp_session "@rx ^[0-9a-f]+\|\|\d+\|\|\d+$" \
 # Operator @unconditionalMatch is used instead of a SecAction because of a bug
 # in ModSecurity v3 which prevents SecActions to be removed using ctl action.
 # _wp_http_referer and wp_http_referer are passed on a lot of wp-admin pages
+# _wp_http_referer and wp_http_referer tend to contain very similar data, it's
+# recommended to keep the disabled rules in sync between these parameters.
 SecRule REQUEST_FILENAME "@unconditionalMatch" \
     "id:9507350,\
     phase:1,\
@@ -469,7 +471,9 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     ctl:ruleRemoveTargetById=932200;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=932235;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=932236;ARGS:_wp_http_referer,\
+    ctl:ruleRemoveTargetById=932370;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=941100;ARGS:_wp_http_referer,\
+    ctl:ruleRemoveTargetById=942120;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942130;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942200;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942230;ARGS:_wp_http_referer,\
@@ -483,15 +487,19 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     ctl:ruleRemoveTargetById=931130;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=932150;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=932200;ARGS:wp_http_referer,\
+    ctl:ruleRemoveTargetById=932235;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=932236;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=932370;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=941100;ARGS:wp_http_referer,\
+    ctl:ruleRemoveTargetById=942120;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942130;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942200;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942230;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942260;ARGS:wp_http_referer,\
+    ctl:ruleRemoveTargetById=942430;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942431;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942432;ARGS:wp_http_referer,\
+    ctl:ruleRemoveTargetById=942440;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=932236;ARGS:_wpnonce,\
     ctl:ruleRemoveTargetById=942450;ARGS:_wpnonce,\
     ver:'wordpress-rule-exclusions-plugin/1.0.1'"

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -451,7 +451,7 @@ SecRule REQUEST_COOKIES:_wp_session "@rx ^[0-9a-f]+\|\|\d+\|\|\d+$" \
 
 # Operator @unconditionalMatch is used instead of a SecAction because of a bug
 # in ModSecurity v3 which prevents SecActions to be removed using ctl action.
-# _wp_http_referer and wp_http_referer are passed on a lot of wp-admin pages
+# _wp_http_referer and wp_http_referer are passed on a lot of wp-admin pages.
 # _wp_http_referer and wp_http_referer tend to contain very similar data, it's
 # recommended to keep the disabled rules in sync between these parameters.
 SecRule REQUEST_FILENAME "@unconditionalMatch" \

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507350.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507350.yaml
@@ -162,3 +162,20 @@ tests:
           output:
             no_log_contains: |-
               id "920230"|id "932235"|id "932236"|id "942430"|id "942431"|id "942432"|id "942450"
+  - test_title: 9507350-10
+    desc: Editing a post after filtering post entries
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: GET
+            version: "HTTP/1.1"
+            uri: /get/wp-admin/edit.php?s=&post_status=all&post_type=post&_wpnonce=1234567890abcdef&_wp_http_referer=%2Fwp-admin%2Fedit.php%3Fs%26post_status%3Dall%26post_type%3Dpost%26action%3D-1%26m%3D0%26cat%3D0%26filter_action%3DFilter%26paged%3D1%26action2%3D-1&action=-1&m=0&cat=0&filter_action=Filter&paged=1&action2=-1
+          output:
+            no_log_contains: |-
+              id "920230"|id "932235"|id "932236"|id "942120"|id "942430"|id "942431"|id "942432"|id "942450"


### PR DESCRIPTION
Fixes a false positive at PL-2 when clicking on `filter` to filter down posts and then editing a post.

I noticed this false positive while working on #71 

`_wp_http_referer` and `wp_http_referer` largely consists of the same kind of data so I synced up the disabled rules, it should catch a false positive or two that we're not aware of.