### PR TITLE
feat: add support for 3rd party themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ OWASP CRS (CRS).
 
 This plugin only supports functionality provided with vanilla WordPress (without plugins installed). False positives that are due to WordPress plugins must be resolved with [custom rule exclusions](https://coreruleset.org/docs/concepts/false_positives_tuning/).
 
+3rd Party themes are supported for both block based themes and classic site editor themes, however 3rd party theme plugins and builders are not supported, those must be resoved with an [custom rule exclusions](https://coreruleset.org/docs/concepts/false_positives_tuning/).
+
 ## Installation
 
 For full and up to date instructions for the different available plugin

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ OWASP CRS (CRS).
 
 This plugin only supports functionality provided with vanilla WordPress (without plugins installed). False positives that are due to WordPress plugins must be resolved with [custom rule exclusions](https://coreruleset.org/docs/concepts/false_positives_tuning/).
 
-3rd Party themes are supported for both block based themes and classic site editor themes, however 3rd party theme plugins and builders are not supported, those must be resoved with an [custom rule exclusions](https://coreruleset.org/docs/concepts/false_positives_tuning/).
+3rd Party themes are supported for both block based themes and classic site editor themes, however 3rd party theme plugins and builders are not supported, those must be tuned manually with a [custom rule exclusions](https://coreruleset.org/docs/concepts/false_positives_tuning/).
 
 ## Installation
 

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -1143,7 +1143,20 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     nolog,\
     ctl:ruleRemoveById=921180,\
     ctl:ruleRemoveTargetById=920273;ARGS_NAMES:load[],\
+    ctl:ruleRemoveTargetById=921220;ARGS_NAMES:load[],\
     ctl:ruleRemoveTargetById=942432;ARGS_NAMES:load[],\
+    ctl:ruleRemoveTargetById=920273;ARGS_NAMES:load[chunk_0],\
+    ctl:ruleRemoveTargetById=921220;ARGS_NAMES:load[chunk_0],\
+    ctl:ruleRemoveTargetById=942432;ARGS_NAMES:load[chunk_0],\
+    ctl:ruleRemoveTargetById=920273;ARGS_NAMES:load[chunk_1],\
+    ctl:ruleRemoveTargetById=921220;ARGS_NAMES:load[chunk_1],\
+    ctl:ruleRemoveTargetById=942432;ARGS_NAMES:load[chunk_1],\
+    ctl:ruleRemoveTargetById=920273;ARGS_NAMES:load[chunk_2],\
+    ctl:ruleRemoveTargetById=921220;ARGS_NAMES:load[chunk_2],\
+    ctl:ruleRemoveTargetById=942432;ARGS_NAMES:load[chunk_2],\
+    ctl:ruleRemoveTargetById=920273;ARGS_NAMES:load[chunk_3],\
+    ctl:ruleRemoveTargetById=921220;ARGS_NAMES:load[chunk_3],\
+    ctl:ruleRemoveTargetById=942432;ARGS_NAMES:load[chunk_3],\
     ctl:ruleRemoveTargetById=932236;ARGS:load[],\
     ctl:ruleRemoveTargetById=942360;ARGS:load[],\
     ctl:ruleRemoveTargetById=942430;ARGS:load[],\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -454,7 +454,6 @@ SecRule ARGS:wp_customize "@streq on" \
         ctl:ruleRemoveTargetById=942520;ARGS:partials,\
         ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
         ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
-        ctl:ruleRemoveTargetById=920420;REQUEST_BODY,\
         ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customized,\
         ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_changeset_uuid,\
         ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_theme,\
@@ -479,7 +478,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetById=942432;ARGS:customize_changeset_uuid,\
             ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
             ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
-            ctl:ruleRemoveTargetById=920420;REQUEST_BODY,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:changes,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customized,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customize_changeset_data,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -430,6 +430,70 @@ SecRule REQUEST_FILENAME "@rx /wp-json/batch/v[0-9]$" \
         ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
         ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
+# Previewing changes made to site via customizer
+SecRule ARGS:wp_customize "@streq on" \
+    "id:9507202,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'wordpress-rule-exclusions-plugin/1.1.0',\
+    chain"
+    SecRule &ARGS:wp_customize "@eq 1" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:customize_theme "@eq 2" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=932200;ARGS:partials,\
+            ctl:ruleRemoveTargetById=932240;ARGS:partials,\
+            ctl:ruleRemoveTargetById=942370;ARGS:partials,\
+            ctl:ruleRemoveTargetById=942430;ARGS:partials,\
+            ctl:ruleRemoveTargetById=942431;ARGS:partials,\
+            ctl:ruleRemoveTargetById=942432;ARGS:partials,\
+            ctl:ruleRemoveTargetById=942520;ARGS:partials,\
+            ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
+            ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customized,\
+            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_changeset_uuid,\
+            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_theme,\
+            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_autosaved,\
+            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_messenger_channel,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customized"
+
+# Saving changes made via site customizer
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
+    "id:9507203,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'wordpress-rule-exclusions-plugin/1.1.0',\
+    chain"
+    SecRule ARGS:wp_customize "@streq on" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:wp_customize "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:changes,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customize_changeset_data,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:data"
+
+# Opening site customizer
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/customize.php" \
+    "id:9507204,\
+    phase:4,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'wordpress-rule-exclusions-plugin/1.1.0',\
+    chain"
+    SecRule RESPONSE_BODY "@contains Invalid date." \
+        "t:none,\
+        chain"
+        SecRule REQUEST_METHOD "@streq GET" \
+            "t:none,\
+            ctl:ruleRemoveById=953101"
+
 #
 # [ Cookies ]
 
@@ -1036,6 +1100,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
     pass,\
     t:none,\
     nolog,\
+    ctl:ruleRemoveTargetById=932236;ARGS_NAMES:cat,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:s,\
     ver:'wordpress-rule-exclusions-plugin/1.1.0'"
 

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -443,12 +443,14 @@ SecRule ARGS:wp_customize "@streq on" \
         "t:none,\
         ctl:ruleRemoveTargetById=920273;ARGS:customize_autosaved,\
         ctl:ruleRemoveTargetById=942432;ARGS:customize_changeset_uuid,\
+        ctl:ruleRemoveTargetById=920273;ARGS:partials,\
         ctl:ruleRemoveTargetById=932200;ARGS:partials,\
         ctl:ruleRemoveTargetById=932240;ARGS:partials,\
         ctl:ruleRemoveTargetById=942370;ARGS:partials,\
         ctl:ruleRemoveTargetById=942430;ARGS:partials,\
         ctl:ruleRemoveTargetById=942431;ARGS:partials,\
         ctl:ruleRemoveTargetById=942432;ARGS:partials,\
+        ctl:ruleRemoveTargetById=942460;ARGS:partials,\
         ctl:ruleRemoveTargetById=942520;ARGS:partials,\
         ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
         ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -441,27 +441,24 @@ SecRule ARGS:wp_customize "@streq on" \
     chain"
     SecRule &ARGS:wp_customize "@eq 1" \
         "t:none,\
-        chain"
-        SecRule &ARGS:customize_theme "@eq 2" \
-            "t:none,\
-            ctl:ruleRemoveTargetById=920273;ARGS:customize_autosaved,\
-            ctl:ruleRemoveTargetById=942432;ARGS:customize_changeset_uuid,\
-            ctl:ruleRemoveTargetById=932200;ARGS:partials,\
-            ctl:ruleRemoveTargetById=932240;ARGS:partials,\
-            ctl:ruleRemoveTargetById=942370;ARGS:partials,\
-            ctl:ruleRemoveTargetById=942430;ARGS:partials,\
-            ctl:ruleRemoveTargetById=942431;ARGS:partials,\
-            ctl:ruleRemoveTargetById=942432;ARGS:partials,\
-            ctl:ruleRemoveTargetById=942520;ARGS:partials,\
-            ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
-            ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
-            ctl:ruleRemoveTargetById=920420;REQUEST_BODY,\
-            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customized,\
-            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_changeset_uuid,\
-            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_theme,\
-            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_autosaved,\
-            ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_messenger_channel,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customized"
+        ctl:ruleRemoveTargetById=920273;ARGS:customize_autosaved,\
+        ctl:ruleRemoveTargetById=942432;ARGS:customize_changeset_uuid,\
+        ctl:ruleRemoveTargetById=932200;ARGS:partials,\
+        ctl:ruleRemoveTargetById=932240;ARGS:partials,\
+        ctl:ruleRemoveTargetById=942370;ARGS:partials,\
+        ctl:ruleRemoveTargetById=942430;ARGS:partials,\
+        ctl:ruleRemoveTargetById=942431;ARGS:partials,\
+        ctl:ruleRemoveTargetById=942432;ARGS:partials,\
+        ctl:ruleRemoveTargetById=942520;ARGS:partials,\
+        ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
+        ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+        ctl:ruleRemoveTargetById=920420;REQUEST_BODY,\
+        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customized,\
+        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_changeset_uuid,\
+        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_theme,\
+        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_autosaved,\
+        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_messenger_channel,\
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customized"
 
 # Saving changes made via site customizer
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
@@ -482,6 +479,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
             ctl:ruleRemoveTargetById=920420;REQUEST_BODY,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:changes,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customized,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customize_changeset_data,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:data"
 

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -1144,22 +1144,31 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     ctl:ruleRemoveById=921180,\
     ctl:ruleRemoveTargetById=920273;ARGS_NAMES:load[],\
     ctl:ruleRemoveTargetById=942432;ARGS_NAMES:load[],\
+    ctl:ruleRemoveTargetById=932236;ARGS:load[],\
     ctl:ruleRemoveTargetById=942360;ARGS:load[],\
     ctl:ruleRemoveTargetById=942430;ARGS:load[],\
     ctl:ruleRemoveTargetById=942431;ARGS:load[],\
     ctl:ruleRemoveTargetById=942432;ARGS:load[],\
     ctl:ruleRemoveTargetById=932236;ARGS:load[chunk_0],\
+    ctl:ruleRemoveTargetById=942360;ARGS:load[chunk_0],\
     ctl:ruleRemoveTargetById=942430;ARGS:load[chunk_0],\
     ctl:ruleRemoveTargetById=942431;ARGS:load[chunk_0],\
     ctl:ruleRemoveTargetById=942432;ARGS:load[chunk_0],\
     ctl:ruleRemoveTargetById=932236;ARGS:load[chunk_1],\
+    ctl:ruleRemoveTargetById=942360;ARGS:load[chunk_1],\
     ctl:ruleRemoveTargetById=942430;ARGS:load[chunk_1],\
     ctl:ruleRemoveTargetById=942431;ARGS:load[chunk_1],\
     ctl:ruleRemoveTargetById=942432;ARGS:load[chunk_1],\
     ctl:ruleRemoveTargetById=932236;ARGS:load[chunk_2],\
+    ctl:ruleRemoveTargetById=942360;ARGS:load[chunk_2],\
     ctl:ruleRemoveTargetById=942430;ARGS:load[chunk_2],\
     ctl:ruleRemoveTargetById=942431;ARGS:load[chunk_2],\
     ctl:ruleRemoveTargetById=942432;ARGS:load[chunk_2],\
+    ctl:ruleRemoveTargetById=932236;ARGS:load[chunk_3],\
+    ctl:ruleRemoveTargetById=942360;ARGS:load[chunk_3],\
+    ctl:ruleRemoveTargetById=942430;ARGS:load[chunk_3],\
+    ctl:ruleRemoveTargetById=942431;ARGS:load[chunk_3],\
+    ctl:ruleRemoveTargetById=942432;ARGS:load[chunk_3],\
     ctl:ruleRemoveTargetById=920100;REQUEST_LINE,\
     ver:'wordpress-rule-exclusions-plugin/1.1.0'"
 

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -444,6 +444,8 @@ SecRule ARGS:wp_customize "@streq on" \
         chain"
         SecRule &ARGS:customize_theme "@eq 2" \
             "t:none,\
+            ctl:ruleRemoveTargetById=920273;ARGS:customize_autosaved,\
+            ctl:ruleRemoveTargetById=942432;ARGS:customize_changeset_uuid,\
             ctl:ruleRemoveTargetById=932200;ARGS:partials,\
             ctl:ruleRemoveTargetById=932240;ARGS:partials,\
             ctl:ruleRemoveTargetById=942370;ARGS:partials,\
@@ -453,6 +455,7 @@ SecRule ARGS:wp_customize "@streq on" \
             ctl:ruleRemoveTargetById=942520;ARGS:partials,\
             ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
             ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+            ctl:ruleRemoveTargetById=920420;REQUEST_BODY,\
             ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customized,\
             ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_changeset_uuid,\
             ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:customize_theme,\
@@ -474,6 +477,10 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         chain"
         SecRule &ARGS:wp_customize "@eq 1" \
             "t:none,\
+            ctl:ruleRemoveTargetById=942432;ARGS:customize_changeset_uuid,\
+            ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
+            ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+            ctl:ruleRemoveTargetById=920420;REQUEST_BODY,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:changes,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:customize_changeset_data,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:data"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
@@ -72,7 +72,7 @@ tests:
               vices%5D%22%3A%22mobile%22%7D&customize_messenger_channel=preview-11
           output:
             no_log_contains: |-
-              id "920272"|id "920273"|id "920420"|id "921180"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
+              id "920272"|id "920273"|id "921180"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
   - test_title: 9507202-2
     desc: |
       Previewing changes made to site via customizer
@@ -98,4 +98,4 @@ tests:
               %3A%2210%22%2C%22narrowContainerWidth%22%3A%22570%22%2C%22wideOffset%22%3A%22177%22%2C%22buttonMinHeight%22%3A%2262%22%2C%22breadcrumb_separator%22%3A%22type-3%22%7D
           output:
             no_log_contains: |-
-              id "920272"|id "920273"|id "920420"|id "921180"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
+              id "920272"|id "920273"|id "921180"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
@@ -70,4 +70,4 @@ tests:
               vices%5D%22%3A%22mobile%22%7D&customize_messenger_channel=preview-11
           output:
             no_log_contains: |-
-              id "920272"|id "920273"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
+              id "920272"|id "920273"|id "920420"|id "921180"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
@@ -73,7 +73,7 @@ tests:
           output:
             no_log_contains: |-
               id "920272"|id "920273"|id "920420"|id "921180"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
-  - test_title: 9507202-1
+  - test_title: 9507202-2
     desc: |
       Previewing changes made to site via customizer
       Theme: Blocksy

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
@@ -6,7 +6,9 @@ meta:
   name: 9507202.yaml
 tests:
   - test_title: 9507202-1
-    desc: Previewing changes made to site via customizer
+    desc: |
+      Previewing changes made to site via customizer
+      Theme: Astra
     stages:
       - stage:
           input:
@@ -68,6 +70,32 @@ tests:
               mobile-unit%22%3A%22px%22%7D%2C%22astra-typography-presets%22%3A%22typo-preset-06%22%2C%22astra-settings%5Bsite-accessibility-toggle%5D%22%3Afalse%2C%22astra-settings%5Bsingle-post-ast-content-layout%5D%22%3A%22normal-
               width-container%22%2C%22astra-settings%5Bsingle-page-ast-content-layout%5D%22%3A%22default%22%2C%22astra-settings%5Bast-search-content-layout%5D%22%3A%22full-width-container%22%2C%22astra-settings%5Bscroll-to-top-on-de
               vices%5D%22%3A%22mobile%22%7D&customize_messenger_channel=preview-11
+          output:
+            no_log_contains: |-
+              id "920272"|id "920273"|id "920420"|id "921180"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
+  - test_title: 9507202-1
+    desc: |
+      Previewing changes made to site via customizer
+      Theme: Blocksy
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+            port: 80
+            method: POST
+            version: "HTTP/1.1"
+            uri: /?customize_changeset_uuid=bdf1e7aa-c9bf-4d19-a4b1-54a4fb960085&customize_autosaved=on&customize_preview_nonce=1624b1200d
+            data: >-
+              wp_customize=on&nonce=1624b1200d&customize_theme=blocksy&customized=%7B%22maxSiteWidth%22%3A%221690%22%2C%22contentAreaSpacing%22%3A
+              %22237px%22%2C%22contentEdgeSpacing%22%3A%2210%22%2C%22narrowContainerWidth%22%3A%22570%22%2C%22wideOffset%22%3A%22177%22%2C%22buttonMinHeight%22%3A
+              %2262%22%2C%22breadcrumb_separator%22%3A%22type-3%22%7D&customize_changeset_uuid=bdf1e7aa-c9bf-4d19-a4b1-54a4fb960085&partials=%7B%22breadcrumb_separator%22
+              %3A%5B%7B%7D%5D%7D&wp_customize_render_partials=1&action=&customized=%7B%22maxSiteWidth%22%3A%221690%22%2C%22contentAreaSpacing%22%3A%22237px%22%2C%22contentEdgeSpacing%22
+              %3A%2210%22%2C%22narrowContainerWidth%22%3A%22570%22%2C%22wideOffset%22%3A%22177%22%2C%22buttonMinHeight%22%3A%2262%22%2C%22breadcrumb_separator%22%3A%22type-3%22%7D
           output:
             no_log_contains: |-
               id "920272"|id "920273"|id "920420"|id "921180"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507202.yaml
@@ -1,0 +1,73 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Wordpress Rule Exclusions Plugin"
+  enabled: true
+  name: 9507202.yaml
+tests:
+  - test_title: 9507202-1
+    desc: Previewing changes made to site via customizer
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: POST
+            version: "HTTP/1.1"
+            uri: /?customize_changeset_uuid=c7fd05af-0c4d-465d-a35d-08ddd5748a9b&customize_theme=astra&customize_messenger_channel=preview-11&customize_autosaved=on
+            data: >-
+              _method=GET&wp_customize=on&customize_theme=astra&nonce=9a330089e8&customize_changeset_uuid=c7fd05af-0c4d-465d-a35d-08ddd5748a9b&customize_autosaved=on
+              &customized=%7B%22show_on_front%22%3A%22posts%22%2C%22astra-settings%5Bsite-layout-outside-bg-obj-responsive%5D%22%3A%7B%22desktop%22%3A%7B%22background-
+              color%22%3A%22var%28--ast-global-color-5%29%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center
+              +center%22%2C%22background-size%22%3A%22auto%22%2C%22background-attachment%22%3A%22scroll%22%2C%22background-type%22%3A%22color%22%2C%22background-media%22%3A%22%22%2C%22overlay
+              -type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%2C%22tablet%22%3A%7B%22background-color%22%3A%22%22%2C%22background-
+              image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A%22auto%22%2C%22background-attachment%22%3A%22scroll%22%2C%22background
+              -type%22%3A%22%22%2C%22background-media%22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%2C%
+              22mobile%22%3A%7B%22background-color%22%3A%22%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center+center%22%2C
+              %22background-size%22%3A%22auto%22%2C%22background-attachment%22%3A%22scroll%22%2C%22background-type%22%3A%22%22%2C%22background-media%22%3A%22%22%2C%22overlay-type%22%3A%22%22
+              %2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%7D%2C%22astra-settings%5Bcontent-bg-obj-responsive%5D%22%3A%7B%22desktop%22
+              %3A%7B%22background-color%22%3A%22var%28--ast-global-color-4%29%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center
+              +center%22%2C%22background-size%22%3A%22auto%22%2C%22background-attachment%22%3A%22scroll%22%2C%22background-type%22%3A%22color%22%2C%22background-media%22%3A%22%22%2C%22overlay-
+              type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%2C%22tablet%22%3A%7B%22background-color%22%3A%22var%28--
+              ast-global-color-4%29%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A
+              %22auto%22%2C%22background-attachment%22%3A%22scroll%22%2C%22background-type%22%3A%22color%22%2C%22background-media%22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-
+              color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%2C%22mobile%22%3A%7B%22background-color%22%3A%22var%28--ast-global-color-4%29%22%2C
+              %22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A%22auto%22%2C%22background-attachment%22%3A
+              %22scroll%22%2C%22background-type%22%3A%22color%22%2C%22background-media%22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%22%2C%22overlay-gradient
+              %22%3A%22%22%7D%7D%2C%22astra-settings%5Bglobal-color-palette%5D%22%3A%7B%22palette%22%3A%5B%22%230067FF%22%2C%22%23005EE9%22%2C%22%230F172A%22%2C%22%23364151%22%2C%22%23FFFFFF%22%2C%22%23E7F6FF
+              %22%2C%22%23070614%22%2C%22%23D1DAE5%22%2C%22%23222222%22%5D%2C%22flag%22%3Afalse%7D%2C%22astra-color-palettes%22%3A%7B%22currentPalette%22%3A%22palette_2%22%2C%22palettes%22%3A%7B%22palette_1%22%3A%
+              5B%22%23046bd2%22%2C%22%23045cb4%22%2C%22%231e293b%22%2C%22%23334155%22%2C%22%23FFFFFF%22%2C%22%23F0F5FA%22%2C%22%23111111%22%2C%22%23D1D5DB%22%2C%22%23111111%22%5D%2C%22palette_2%22%3A%5B%22%230067FF
+              %22%2C%22%23005EE9%22%2C%22%230F172A%22%2C%22%23364151%22%2C%22%23FFFFFF%22%2C%22%23E7F6FF%22%2C%22%23070614%22%2C%22%23D1DAE5%22%2C%22%23222222%22%5D%2C%22palette_3%22%3A%5B%22%236528F7%22%2C%22%235511F8%22
+              %2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%23FFFFFF%22%2C%22%23F2F0FE%22%2C%22%230D0614%22%2C%22%23D8D8F5%22%2C%22%23222222%22%5D%2C%22palette_4%22%3A%5B%22%230085FF%22%2C%22%230177E3%22%2C%22%23FFFFFF%22%2C
+              %22%23E7F6FF%22%2C%22%23212A37%22%2C%22%230F172A%22%2C%22%234F5B62%22%2C%22%23070614%22%2C%22%23222222%22%5D%7D%2C%22presets%22%3A%7B%22Oak%22%3A%5B%22%230067FF%22%2C%22%23005EE9%22%2C%22%230F172A%22%2C%22%23364151
+              %22%2C%22%23FFFFFF%22%2C%22%23E7F6FF%22%2C%22%23070614%22%2C%22%23D1DAE5%22%2C%22%23222222%22%5D%2C%22Lavender%22%3A%5B%22%236528F7%22%2C%22%235511F8%22%2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%23FFFFFF%22%2C%22
+              %23F2F0FE%22%2C%22%230D0614%22%2C%22%23D8D8F5%22%2C%22%23222222%22%5D%2C%22Cedar%22%3A%5B%22%23DD183B%22%2C%22%23CC1939%22%2C%22%230F172A%22%2C%22%233A3A3A%22%2C%22%23FFFFFF%22%2C%22%23FFEDE6%22%2C%22%23140609%22
+              %2C%22%23FFD1BF%22%2C%22%23222222%22%5D%2C%22Willow%22%3A%5B%22%2354B435%22%2C%22%23379237%22%2C%22%230F172A%22%2C%22%232F3B40%22%2C%22%23FFFFFF%22%2C%22%23EDFBE2%22%2C%22%230C1406%22%2C%22%23D5EAD8%22%2C%22%23222222%22
+              %5D%2C%22Lily%22%3A%5B%22%23DCA54A%22%2C%22%23D09A40%22%2C%22%230F172A%22%2C%22%234A4A4A%22%2C%22%23FFFFFF%22%2C%22%23FAF5E5%22%2C%22%23141004%22%2C%22%23F0E6C5%22%2C%22%23222222%22%5D%2C%22Rose%22%3A%5B%22%23FB5FAB%
+              22%2C%22%23EA559D%22%2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%23FFFFFF%22%2C%22%23FCEEF5%22%2C%22%23140610%22%2C%22%23FAD8E9%22%2C%22%23222222%22%5D%2C%22Sage%22%3A%5B%22%231B9C85%22%2C%22%23178E79%22%2C%22%230F172A%
+              22%2C%22%23454F5E%22%2C%22%23FFFFFF%22%2C%22%23EDF6EE%22%2C%22%2306140C%22%2C%22%23D4F3D7%22%2C%22%23222222%22%5D%2C%22Sunflower%22%3A%5B%22%23FD9800%22%2C%22%23E98C00%22%2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%2
+              3FFFFFF%22%2C%22%23FEF9E1%22%2C%22%23141006%22%2C%22%23F9F0C8%22%2C%22%23222222%22%5D%2C%22Maple%22%3A%5B%22%23FF6210%22%2C%22%23F15808%22%2C%22%231C0D0A%22%2C%22%23353535%22%2C%22%23FFFFFF%22%2C%22%23FEF1E4%22%2C%
+              22%23140B06%22%2C%22%23E5D7D1%22%2C%22%23222222%22%5D%2C%22Birch%22%3A%5B%22%23737880%22%2C%22%2365696F%22%2C%22%23151616%22%2C%22%23393C40%22%2C%22%23FFFFFF%22%2C%22%23F6F6F6%22%2C%22%23232529%22%2C%22%23F1F0F0%22
+              %2C%22%23222222%22%5D%2C%22Dark%22%3A%5B%22%230085FF%22%2C%22%230177E3%22%2C%22%23FFFFFF%22%2C%22%23E7F6FF%22%2C%22%23212A37%22%2C%22%230F172A%22%2C%22%234F5B62%22%2C%22%23070614%22%2C%22%23222222%22%5D%7D%2C%22pres
+              etNames%22%3A%7B%22palette_1%22%3Anull%2C%22palette_2%22%3A%22Oak%22%2C%22palette_3%22%3A%22Lavender%22%2C%22palette_4%22%3A%22Dark%22%7D%2C%22flag%22%3Afalse%7D%2C%22astra-settings%5Bbody-font-family%5D%22%3A%22%27
+              Work+Sans%27%2C+sans-serif%22%2C%22astra-settings%5Bbody-font-variant%5D%22%3A%22400%22%2C%22astra-settings%5Bfont-size-body%5D%22%3A%7B%22desktop%22%3A16%2C%22tablet%22%3A16%2C%22mobile%22%3A16%2C%22desktop-unit%22
+              %3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%2C%22astra-settings%5Bheadings-font-family%5D%22%3A%22%27DM+Serif+Display%27%2C+serif%22%2C%22astra-settings%5Bheadings-font-variant%5D%22%3A
+              %22400%22%2C%22astra-settings%5Bwp-blocks-ui%5D%22%3A%22custom%22%2C%22astra-settings%5Bwp-blocks-global-padding%5D%22%3A%7B%22desktop%22%3A%7B%22top%22%3A%2221%22%2C%22right%22%3A%2221%22%2C%22bottom%22%3A%2221%22%2C%
+              22left%22%3A%2221%22%7D%2C%22tablet%22%3A%7B%22top%22%3A%22%22%2C%22right%22%3A%22%22%2C%22bottom%22%3A%22%22%2C%22left%22%3A%22%22%7D%2C%22mobile%22%3A%7B%22top%22%3A%22%22%2C%22right%22%3A%22%22%2C%22bottom%22%3A%22%
+              22%2C%22left%22%3A%22%22%7D%2C%22desktop-unit%22%3A%22em%22%2C%22tablet-unit%22%3A%22em%22%2C%22mobile-unit%22%3A%22em%22%7D%2C%22astra-settings%5Bfont-size-h1%5D%22%3A%7B%22desktop%22%3A48%2C%22tablet%22%3A40%2C%22mob
+              ile%22%3A36%2C%22desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%2C%22astra-settings%5Bfont-size-h2%5D%22%3A%7B%22desktop%22%3A38%2C%22tablet%22%3A32%2C%22mobile%22%3A28%2C%2
+              2desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%2C%22astra-settings%5Bfont-size-h3%5D%22%3A%7B%22desktop%22%3A30%2C%22tablet%22%3A26%2C%22mobile%22%3A22%2C%22desktop-unit%22
+              %3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%2C%22astra-settings%5Bfont-size-h4%5D%22%3A%7B%22desktop%22%3A24%2C%22tablet%22%3A20%2C%22mobile%22%3A18%2C%22desktop-unit%22%3A%22px%22%2C%2
+              2tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%2C%22astra-settings%5Bfont-size-h5%5D%22%3A%7B%22desktop%22%3A21%2C%22tablet%22%3A17%2C%22mobile%22%3A15%2C%22desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%
+              3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%2C%22astra-settings%5Bfont-size-h6%5D%22%3A%7B%22desktop%22%3A17%2C%22tablet%22%3A15%2C%22mobile%22%3A14%2C%22desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22
+              mobile-unit%22%3A%22px%22%7D%2C%22astra-typography-presets%22%3A%22typo-preset-06%22%2C%22astra-settings%5Bsite-accessibility-toggle%5D%22%3Afalse%2C%22astra-settings%5Bsingle-post-ast-content-layout%5D%22%3A%22normal-
+              width-container%22%2C%22astra-settings%5Bsingle-page-ast-content-layout%5D%22%3A%22default%22%2C%22astra-settings%5Bast-search-content-layout%5D%22%3A%22full-width-container%22%2C%22astra-settings%5Bscroll-to-top-on-de
+              vices%5D%22%3A%22mobile%22%7D&customize_messenger_channel=preview-11
+          output:
+            no_log_contains: |-
+              id "920272"|id "920273"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
@@ -6,7 +6,9 @@ meta:
   name: 9507203.yaml
 tests:
   - test_title: 9507203-1
-    desc: Saving changes made via site customizer
+    desc: |
+      Saving changes made via site customizer
+      Theme: Astra
     stages:
       - stage:
           input:
@@ -73,6 +75,36 @@ tests:
               s%5Bsite-accessibility-toggle%5D%22%3A%7B%22value%22%3Afalse%7D%2C%22astra-settings%5Bsingle-post-ast-content-layout%5D%22%3A%7B%22value%22%3A%22normal-width-container%22%7D%2C%22astra-settin
               gs%5Bsingle-page-ast-content-layout%5D%22%3A%7B%22value%22%3A%22default%22%7D%2C%22astra-settings%5Bast-search-content-layout%5D%22%3A%7B%22value%22%3A%22full-width-container%22%7D%2C%22astra
               -settings%5Bscroll-to-top-on-devices%5D%22%3A%7B%22value%22%3A%22mobile%22%7D%7D&customize_changeset_autosave=true&action=customize_save&customize_preview_nonce=9a330089e8
+          output:
+            no_log_contains: |-
+              id "920272"|id "920273"|id "920420"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
+  - test_title: 9507203-2
+    desc: |
+      Saving changes made via site customizer
+      Theme: Blocksy
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+            port: 80
+            method: POST
+            version: "HTTP/1.1"
+            uri: /post/wp-admin/admin-ajax.php
+            data: >-
+              wp_customize=on&customize_theme=blocksy&nonce=00265d507a&customize_changeset_uuid=bc3de93c-59f1-4501-903d-d8229f2ee7bf&customize_autosaved
+              =on&customized=%7B%22maxSiteWidth%22%3A%221763%22%2C%22contentAreaSpacing%22%3A%22235px%22%2C%22contentEdgeSpacing%22%3A%223%22%2C%
+              22narrowContainerWidth%22%3A%22928%22%2C%22wideOffset%22%3A%2266%22%2C%22buttonMinHeight%22%3A%2273%22%2C%22buttonHoverEffect%22%3A%22yes
+              %22%2C%22buttonTextColor%22%3A%7B%22default%22%3A%7B%22color%22%3A%22%230e0606%22%7D%2C%22hover%22%3A%7B%22color%22%3A%22%23260808%22%7D
+              %7D%2C%22buttonColor%22%3A%7B%22default%22%3A%7B%22color%22%3A%22%23344e7f%22%7D%2C%22hover%22%3A%7B%22color%22%3A%22%231a2745%22%7D%7D
+              %2C%22buttonBorder%22%3A%7B%22width%22%3A1%2C%22style%22%3A%22dashed%22%2C%22color%22%3A%7B%22color%22%3A%22rgba(224%2C+229%2C+235%2C+0.5)
+              %22%7D%2C%22secondColor%22%3A%7B%22color%22%3A%22rgba(224%2C+229%2C+235%2C+0.7)%22%7D%7D%2C%22breadcrumb_separator%22%3A%22type-3%22%2C%22breadcrumbsFontColor
+              %22%3A%7B%22default%22%3A%7B%22color%22%3A%22%23602d2d%22%7D%2C%22initial%22%3A%7B%22color%22%3A%22%235b2424%22%7D%2C%22hover%22%3A%7B%22color%22%3A%22%23852929%22%7D
+              %7D%7D&customize_changeset_status=publish&action=customize_save&customize_preview_nonce=1624b1200d
           output:
             no_log_contains: |-
               id "920272"|id "920273"|id "920420"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
@@ -1,0 +1,78 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Wordpress Rule Exclusions Plugin"
+  enabled: true
+  name: 9507203.yaml
+tests:
+  - test_title: 9507203-1
+    desc: Saving changes made via site customizer
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+            port: 80
+            method: POST
+            version: "HTTP/1.1"
+            uri: /wp-admin/admin-ajax.php
+            data: >-
+              wp_customize=on&customize_theme=astra&nonce=34ef66fe58&customize_changeset_uuid=c7fd05af-0c4d-465d-a35d-08ddd5748a9b&customize_autosaved=on&customize_changeset_data=%7B%22show_on_front
+              %22%3A%7B%22value%22%3A%22posts%22%7D%2C%22astra-settings%5Bsite-layout-outside-bg-obj-responsive%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A%7B%22background-color%22%3A%22var(--ast-g
+              lobal-color-5)%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A%22auto%22%2C%2
+              2background-attachment%22%3A%22scroll%22%2C%22background-type%22%3A%22color%22%2C%22background-media%22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay
+              -opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%2C%22tablet%22%3A%7B%22background-color%22%3A%22%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2
+              C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A%22auto%22%2C%22background-attachment%22%3A%22scroll%22%2C%22background-type%22%3A%22%22%2C%22background-media%
+              22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%2C%22mobile%22%3A%7B%22background-color%22%3
+              A%22%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A%22auto%22%2C%22background-a
+              ttachment%22%3A%22scroll%22%2C%22background-type%22%3A%22%22%2C%22background-media%22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%2
+              2%2C%22overlay-gradient%22%3A%22%22%7D%7D%7D%2C%22astra-settings%5Bcontent-bg-obj-responsive%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A%7B%22background-color%22%3A%22var(--ast-global-col
+              or-4)%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A%22auto%22%2C%22background-a
+              ttachment%22%3A%22scroll%22%2C%22background-type%22%3A%22color%22%2C%22background-media%22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%2
+              2%22%2C%22overlay-gradient%22%3A%22%22%7D%2C%22tablet%22%3A%7B%22background-color%22%3A%22var(--ast-global-color-4)%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repea
+              t%22%2C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A%22auto%22%2C%22background-attachment%22%3A%22scroll%22%2C%22background-type%22%3A%22color%22%2C%22background
+              -media%22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%22overlay-opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%2C%22mobile%22%3A%7B%22background-color%
+              22%3A%22var(--ast-global-color-4)%22%2C%22background-image%22%3A%22%22%2C%22background-repeat%22%3A%22repeat%22%2C%22background-position%22%3A%22center+center%22%2C%22background-size%22%3A%2
+              2auto%22%2C%22background-attachment%22%3A%22scroll%22%2C%22background-type%22%3A%22color%22%2C%22background-media%22%3A%22%22%2C%22overlay-type%22%3A%22%22%2C%22overlay-color%22%3A%22%22%2C%
+              22overlay-opacity%22%3A%22%22%2C%22overlay-gradient%22%3A%22%22%7D%7D%7D%2C%22astra-settings%5Bglobal-color-palette%5D%22%3A%7B%22value%22%3A%7B%22palette%22%3A%5B%22%230067FF%22%2C%22%23005
+              EE9%22%2C%22%230F172A%22%2C%22%23364151%22%2C%22%23FFFFFF%22%2C%22%23E7F6FF%22%2C%22%23070614%22%2C%22%23D1DAE5%22%2C%22%23222222%22%5D%2C%22flag%22%3Afalse%7D%7D%2C%22astra-color-palettes%22
+              %3A%7B%22value%22%3A%7B%22currentPalette%22%3A%22palette_2%22%2C%22palettes%22%3A%7B%22palette_1%22%3A%5B%22%23046bd2%22%2C%22%23045cb4%22%2C%22%231e293b%22%2C%22%23334155%22%2C%22%23FFFFFF%
+              22%2C%22%23F0F5FA%22%2C%22%23111111%22%2C%22%23D1D5DB%22%2C%22%23111111%22%5D%2C%22palette_2%22%3A%5B%22%230067FF%22%2C%22%23005EE9%22%2C%22%230F172A%22%2C%22%23364151%22%2C%22%23FFFFFF%22%2
+              C%22%23E7F6FF%22%2C%22%23070614%22%2C%22%23D1DAE5%22%2C%22%23222222%22%5D%2C%22palette_3%22%3A%5B%22%236528F7%22%2C%22%235511F8%22%2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%23FFFFFF%22%2C%22
+              %23F2F0FE%22%2C%22%230D0614%22%2C%22%23D8D8F5%22%2C%22%23222222%22%5D%2C%22palette_4%22%3A%5B%22%230085FF%22%2C%22%230177E3%22%2C%22%23FFFFFF%22%2C%22%23E7F6FF%22%2C%22%23212A37%22%2C%22%23
+              0F172A%22%2C%22%234F5B62%22%2C%22%23070614%22%2C%22%23222222%22%5D%7D%2C%22presets%22%3A%7B%22Oak%22%3A%5B%22%230067FF%22%2C%22%23005EE9%22%2C%22%230F172A%22%2C%22%23364151%22%2C%22%23FFFFF
+              F%22%2C%22%23E7F6FF%22%2C%22%23070614%22%2C%22%23D1DAE5%22%2C%22%23222222%22%5D%2C%22Lavender%22%3A%5B%22%236528F7%22%2C%22%235511F8%22%2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%23FFFFFF%22
+              %2C%22%23F2F0FE%22%2C%22%230D0614%22%2C%22%23D8D8F5%22%2C%22%23222222%22%5D%2C%22Cedar%22%3A%5B%22%23DD183B%22%2C%22%23CC1939%22%2C%22%230F172A%22%2C%22%233A3A3A%22%2C%22%23FFFFFF%22%2C%22%
+              23FFEDE6%22%2C%22%23140609%22%2C%22%23FFD1BF%22%2C%22%23222222%22%5D%2C%22Willow%22%3A%5B%22%2354B435%22%2C%22%23379237%22%2C%22%230F172A%22%2C%22%232F3B40%22%2C%22%23FFFFFF%22%2C%22%23EDF
+              BE2%22%2C%22%230C1406%22%2C%22%23D5EAD8%22%2C%22%23222222%22%5D%2C%22Lily%22%3A%5B%22%23DCA54A%22%2C%22%23D09A40%22%2C%22%230F172A%22%2C%22%234A4A4A%22%2C%22%23FFFFFF%22%2C%22%23FAF5E5%22%
+              2C%22%23141004%22%2C%22%23F0E6C5%22%2C%22%23222222%22%5D%2C%22Rose%22%3A%5B%22%23FB5FAB%22%2C%22%23EA559D%22%2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%23FFFFFF%22%2C%22%23FCEEF5%22%2C%22%23
+              140610%22%2C%22%23FAD8E9%22%2C%22%23222222%22%5D%2C%22Sage%22%3A%5B%22%231B9C85%22%2C%22%23178E79%22%2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%23FFFFFF%22%2C%22%23EDF6EE%22%2C%22%2306140C
+              %22%2C%22%23D4F3D7%22%2C%22%23222222%22%5D%2C%22Sunflower%22%3A%5B%22%23FD9800%22%2C%22%23E98C00%22%2C%22%230F172A%22%2C%22%23454F5E%22%2C%22%23FFFFFF%22%2C%22%23FEF9E1%22%2C%22%23141006%2
+              2%2C%22%23F9F0C8%22%2C%22%23222222%22%5D%2C%22Maple%22%3A%5B%22%23FF6210%22%2C%22%23F15808%22%2C%22%231C0D0A%22%2C%22%23353535%22%2C%22%23FFFFFF%22%2C%22%23FEF1E4%22%2C%22%23140B06%22%2C%
+              22%23E5D7D1%22%2C%22%23222222%22%5D%2C%22Birch%22%3A%5B%22%23737880%22%2C%22%2365696F%22%2C%22%23151616%22%2C%22%23393C40%22%2C%22%23FFFFFF%22%2C%22%23F6F6F6%22%2C%22%23232529%22%2C%22%23F1
+              F0F0%22%2C%22%23222222%22%5D%2C%22Dark%22%3A%5B%22%230085FF%22%2C%22%230177E3%22%2C%22%23FFFFFF%22%2C%22%23E7F6FF%22%2C%22%23212A37%22%2C%22%230F172A%22%2C%22%234F5B62%22%2C%22%23070614%22%2
+              C%22%23222222%22%5D%7D%2C%22presetNames%22%3A%7B%22palette_1%22%3Anull%2C%22palette_2%22%3A%22Oak%22%2C%22palette_3%22%3A%22Lavender%22%2C%22palette_4%22%3A%22Dark%22%7D%2C%22flag%22%3Afalse
+              %7D%7D%2C%22astra-settings%5Bfont-size-page-title%5D%22%3A%7B%7D%2C%22astra-settings%5Bbody-font-family%5D%22%3A%7B%22value%22%3A%22'Work+Sans'%2C+sans-serif%22%7D%2C%22astra-settings%5Bbody
+              -font-variant%5D%22%3A%7B%22value%22%3A%22400%22%7D%2C%22astra-settings%5Bfont-size-body%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A16%2C%22tablet%22%3A16%2C%22mobile%22%3A16%2C%22desktop-u
+              nit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%7D%2C%22astra-settings%5Bheadings-font-family%5D%22%3A%7B%22value%22%3A%22'DM+Serif+Display'%2C+serif%22%7D
+              %2C%22astra-settings%5Bheadings-font-variant%5D%22%3A%7B%22value%22%3A%22400%22%7D%2C%22astra-settings%5Bwp-blocks-ui%5D%22%3A%7B%22value%22%3A%22custom%22%7D%2C%22astra-settings%5Bwp-blocks
+              -global-padding%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A%7B%22top%22%3A%2221%22%2C%22right%22%3A%2221%22%2C%22bottom%22%3A%2221%22%2C%22left%22%3A%2221%22%7D%2C%22tablet%22%3A%7B%22top%22
+              %3A%22%22%2C%22right%22%3A%22%22%2C%22bottom%22%3A%22%22%2C%22left%22%3A%22%22%7D%2C%22mobile%22%3A%7B%22top%22%3A%22%22%2C%22right%22%3A%22%22%2C%22bottom%22%3A%22%22%2C%22left%22%3A%22%22%7
+              D%2C%22desktop-unit%22%3A%22em%22%2C%22tablet-unit%22%3A%22em%22%2C%22mobile-unit%22%3A%22em%22%7D%7D%2C%22astra-settings%5Bfont-size-h1%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A48%2C%22ta
+              blet%22%3A40%2C%22mobile%22%3A36%2C%22desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%7D%2C%22astra-settings%5Bfont-size-h2%5D%22%3A%7B%22value%22%
+              3A%7B%22desktop%22%3A38%2C%22tablet%22%3A32%2C%22mobile%22%3A28%2C%22desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%7D%2C%22astra-settings%5Bfont-
+              size-h3%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A30%2C%22tablet%22%3A26%2C%22mobile%22%3A22%2C%22desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D
+              %7D%2C%22astra-settings%5Bfont-size-h4%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A24%2C%22tablet%22%3A20%2C%22mobile%22%3A18%2C%22desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C
+              %22mobile-unit%22%3A%22px%22%7D%7D%2C%22astra-settings%5Bfont-size-h5%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A21%2C%22tablet%22%3A17%2C%22mobile%22%3A15%2C%22desktop-unit%22%3A%22px%22%2C
+              %22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%7D%2C%22astra-settings%5Bfont-size-h6%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A17%2C%22tablet%22%3A15%2C%22mobile%22%3A14%2C%
+              22desktop-unit%22%3A%22px%22%2C%22tablet-unit%22%3A%22px%22%2C%22mobile-unit%22%3A%22px%22%7D%7D%2C%22astra-typography-presets%22%3A%7B%22value%22%3A%22typo-preset-06%22%7D%2C%22astra-setting
+              s%5Bsite-accessibility-toggle%5D%22%3A%7B%22value%22%3Afalse%7D%2C%22astra-settings%5Bsingle-post-ast-content-layout%5D%22%3A%7B%22value%22%3A%22normal-width-container%22%7D%2C%22astra-settin
+              gs%5Bsingle-page-ast-content-layout%5D%22%3A%7B%22value%22%3A%22default%22%7D%2C%22astra-settings%5Bast-search-content-layout%5D%22%3A%7B%22value%22%3A%22full-width-container%22%7D%2C%22astra
+              -settings%5Bscroll-to-top-on-devices%5D%22%3A%7B%22value%22%3A%22mobile%22%7D%7D&customize_changeset_autosave=true&action=customize_save&customize_preview_nonce=9a330089e8
+          output:
+            no_log_contains: |-
+              id "920272"|id "920273"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
@@ -19,7 +19,7 @@ tests:
             port: 80
             method: POST
             version: "HTTP/1.1"
-            uri: /wp-admin/admin-ajax.php
+            uri: /post/wp-admin/admin-ajax.php
             data: >-
               wp_customize=on&customize_theme=astra&nonce=34ef66fe58&customize_changeset_uuid=c7fd05af-0c4d-465d-a35d-08ddd5748a9b&customize_autosaved=on&customize_changeset_data=%7B%22show_on_front
               %22%3A%7B%22value%22%3A%22posts%22%7D%2C%22astra-settings%5Bsite-layout-outside-bg-obj-responsive%5D%22%3A%7B%22value%22%3A%7B%22desktop%22%3A%7B%22background-color%22%3A%22var(--ast-g
@@ -75,4 +75,4 @@ tests:
               -settings%5Bscroll-to-top-on-devices%5D%22%3A%7B%22value%22%3A%22mobile%22%7D%7D&customize_changeset_autosave=true&action=customize_save&customize_preview_nonce=9a330089e8
           output:
             no_log_contains: |-
-              id "920272"|id "920273"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
+              id "920272"|id "920273"|id "920420"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
@@ -77,7 +77,7 @@ tests:
               -settings%5Bscroll-to-top-on-devices%5D%22%3A%7B%22value%22%3A%22mobile%22%7D%7D&customize_changeset_autosave=true&action=customize_save&customize_preview_nonce=9a330089e8
           output:
             no_log_contains: |-
-              id "920272"|id "920273"|id "920420"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
+              id "920272"|id "920273"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
   - test_title: 9507203-2
     desc: |
       Saving changes made via site customizer
@@ -107,4 +107,4 @@ tests:
               %7D%7D&customize_changeset_status=publish&action=customize_save&customize_preview_nonce=1624b1200d
           output:
             no_log_contains: |-
-              id "920272"|id "920273"|id "920420"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"
+              id "920272"|id "920273"|id "932200"|id "932240"|id "942370"|id "942430"|id "942431"|id "942432"|id "942520"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507203.yaml
@@ -96,8 +96,8 @@ tests:
             version: "HTTP/1.1"
             uri: /post/wp-admin/admin-ajax.php
             data: >-
-              wp_customize=on&customize_theme=blocksy&nonce=00265d507a&customize_changeset_uuid=bc3de93c-59f1-4501-903d-d8229f2ee7bf&customize_autosaved
-              =on&customized=%7B%22maxSiteWidth%22%3A%221763%22%2C%22contentAreaSpacing%22%3A%22235px%22%2C%22contentEdgeSpacing%22%3A%223%22%2C%
+              wp_customize=on&customize_theme=blocksy&nonce=00265d507a&customize_changeset_uuid=bc3de93c-59f1-4501-903d-d8229f2ee7bf&customize_autosaved=on
+              &customized=%7B%22maxSiteWidth%22%3A%221763%22%2C%22contentAreaSpacing%22%3A%22235px%22%2C%22contentEdgeSpacing%22%3A%223%22%2C%
               22narrowContainerWidth%22%3A%22928%22%2C%22wideOffset%22%3A%2266%22%2C%22buttonMinHeight%22%3A%2273%22%2C%22buttonHoverEffect%22%3A%22yes
               %22%2C%22buttonTextColor%22%3A%7B%22default%22%3A%7B%22color%22%3A%22%230e0606%22%7D%2C%22hover%22%3A%7B%22color%22%3A%22%23260808%22%7D
               %7D%2C%22buttonColor%22%3A%7B%22default%22%3A%7B%22color%22%3A%22%23344e7f%22%7D%2C%22hover%22%3A%7B%22color%22%3A%22%231a2745%22%7D%7D

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507900.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507900.yaml
@@ -1,12 +1,11 @@
 ---
 meta:
   author: "Esad Cetiner"
-  description: "Wordpress Rule Exclusions Plugin"
+  description: "wp-admin: Loading styles/scripts"
   enabled: true
   name: 9507900.yaml
 tests:
   - test_title: 9507900-1
-    desc: Disable 932236 for ARGS:load[chunk_0]
     stages:
       - stage:
           input:
@@ -16,13 +15,13 @@ tests:
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             version: "HTTP/1.1"
-            uri: /post/wp-admin/load-scripts.php?load[chunk_0]=jquery-core,jquery-migrate,utils
+            uri: /get/wp-admin/load-scripts.php?load[chunk_0]=jquery-core,jquery-migrate,utils
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
   - test_title: 9507900-2
-    desc: Disable 932236 for ARGS:load[chunk_1]
     stages:
       - stage:
           input:
@@ -32,13 +31,13 @@ tests:
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             version: "HTTP/1.1"
-            uri: /post/wp-admin/load-scripts.php?load[chunk_1]=jquery-core,jquery-migrate,utils
+            uri: /get/wp-admin/load-scripts.php?load[chunk_1]=jquery-core,jquery-migrate,utils
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
   - test_title: 9507900-3
-    desc: Disable 932236 for ARGS:load[chunk_0]
     stages:
       - stage:
           input:
@@ -48,13 +47,13 @@ tests:
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             version: "HTTP/1.1"
-            uri: /post/wp-admin/load-styles.php?load[chunk_0]=jquery-core,jquery-migrate,utils
+            uri: /get/wp-admin/load-styles.php?load[chunk_0]=jquery-core,jquery-migrate,utils
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
   - test_title: 9507900-4
-    desc: Disable 932236 for ARGS:load[chunk_1]
     stages:
       - stage:
           input:
@@ -64,8 +63,25 @@ tests:
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             version: "HTTP/1.1"
-            uri: /post/wp-admin/load-styles.php?load[chunk_1]=jquery-core,jquery-migrate,utils
+            uri: /get/wp-admin/load-styles.php?load[chunk_1]=jquery-core,jquery-migrate,utils
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
+  - test_title: 9507900-5
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: GET
+            version: "HTTP/1.1"
+            uri: /get/wp-admin/load-styles.php?c=1&dir=ltr&load%5Bchunk_0%5D=dashicons,common,forms,admin-menu,dashboard,list-tables,edit,revisions,media,themes,about,nav-menus,wp-pointer,widgets,site-icon&load%5Bchunk_1%5D=,l10n,buttons,customize-controls,customize-widgets,wp-block-library,wp-components,wp-widgets,wp-preferences,wp-block-editor,wp-r&load%5Bchunk_2%5D=eusable-blocks,wp-patterns,wp-editor,wp-reset-editor-styles,wp-block-editor-content,wp-editor-classic-layout-styles,wp-edit-bloc&load%5Bchunk_3%5D=ks,wp-customize-widgets,wp-block-directory,wp-format-library,customize-nav-menus,media-views,code-editor,wp-color-picker&ver=6.7.2
+          output:
+            no_log_contains: |-
+              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507900.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507900.yaml
@@ -20,7 +20,7 @@ tests:
             uri: /get/wp-admin/load-scripts.php?load[chunk_0]=jquery-core,jquery-migrate,utils
           output:
             no_log_contains: |-
-              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
+              id "920100"|id "920273"|id "921220"|id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
   - test_title: 9507900-2
     stages:
       - stage:
@@ -36,7 +36,7 @@ tests:
             uri: /get/wp-admin/load-scripts.php?load[chunk_1]=jquery-core,jquery-migrate,utils
           output:
             no_log_contains: |-
-              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
+              id "920100"|id "920273"|id "921220"|id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
   - test_title: 9507900-3
     stages:
       - stage:
@@ -52,7 +52,7 @@ tests:
             uri: /get/wp-admin/load-styles.php?load[chunk_0]=jquery-core,jquery-migrate,utils
           output:
             no_log_contains: |-
-              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
+              id "920100"|id "920273"|id "921220"|id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
   - test_title: 9507900-4
     stages:
       - stage:
@@ -68,7 +68,7 @@ tests:
             uri: /get/wp-admin/load-styles.php?load[chunk_1]=jquery-core,jquery-migrate,utils
           output:
             no_log_contains: |-
-              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
+              id "920100"|id "920273"|id "921220"|id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
   - test_title: 9507900-5
     stages:
       - stage:
@@ -84,4 +84,4 @@ tests:
             uri: /get/wp-admin/load-styles.php?c=1&dir=ltr&load%5Bchunk_0%5D=dashicons,common,forms,admin-menu,dashboard,list-tables,edit,revisions,media,themes,about,nav-menus,wp-pointer,widgets,site-icon&load%5Bchunk_1%5D=,l10n,buttons,customize-controls,customize-widgets,wp-block-library,wp-components,wp-widgets,wp-preferences,wp-block-editor,wp-r&load%5Bchunk_2%5D=eusable-blocks,wp-patterns,wp-editor,wp-reset-editor-styles,wp-block-editor-content,wp-editor-classic-layout-styles,wp-edit-bloc&load%5Bchunk_3%5D=ks,wp-customize-widgets,wp-block-directory,wp-format-library,customize-nav-menus,media-views,code-editor,wp-color-picker&ver=6.7.2
           output:
             no_log_contains: |-
-              id "932236"|id "942360"|id "942430"|id "942431"|id "942432"
+              id "920100"|id "920273"|id "921220"|id "932236"|id "942360"|id "942430"|id "942431"|id "942432"


### PR DESCRIPTION
Adds support for classic 3rd party themes.

I know the idea of adding support for 3rd party plugins has been thrown around, but as others have mentioned that can result in the number of rule exclusions blowing up. All of the requests sent by themes are actually pretty similar, so this should be relatively low effort for a pretty high return, most WordPress users use 3rd party themes because the stock themes are limiting. Some themes add additional functionality via plugins, those won't be supported.

I've tested against the following themes:
Astra
Blocksy
Generate Press
Twenty Twelve
Ocean WP
Zakra