### PR TITLE
fix:FP related to PLugin Editor feature

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -1393,6 +1393,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/plugin-editor.php" \
     chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "t:none,\
+        ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
         ctl:ruleRemoveTargetById=953110;RESPONSE_BODY"
 
 SecMarker "END-WORDPRESS-ADMIN"

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -1382,4 +1382,17 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/update.php" \
     ver:'wordpress-rule-exclusions-plugin/1.1.0',\
     ctl:ruleRemoveTargetById=932236;ARGS:install-plugin-submit"
 
+# Plugin Editor feature
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/plugin-editor.php" \
+    "id:9507975,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'wordpress-rule-exclusions-plugin/1.1.0',\
+    chain"
+    SecRule REQUEST_METHOD "@streq GET" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=953110;RESPONSE_BODY"
+
 SecMarker "END-WORDPRESS-ADMIN"


### PR DESCRIPTION
You can use Plugin Editor to directly edit PHP files, so it needs to be able to display PHP code.