### PR TITLE
fix: fp when setting up wordpress

### DIFF
--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -750,41 +750,45 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
 # [ Installation ]
 #
 
-# WordPress installation: exclude database password
+# Setting up a new WordPress installation
+# Entering the DB password for WordPress
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/setup-config.php" \
     "id:9507410,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'wordpress-rule-exclusions-plugin/1.1.0',\
-    chain"
-    SecRule ARGS:step "@streq 2" \
-        "t:none,\
-        chain"
-        SecRule &ARGS:step "@eq 1" \
-            "t:none,\
-            ctl:ruleRemoveTargetById=932260;ARGS_NAMES:uname,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd"
+    ctl:ruleRemoveTargetById=930130;REQUEST_FILENAME,\
+    ctl:ruleRemoveTargetById=932260;ARGS_NAMES:uname,\
+    ctl:ruleRemoveTargetById=932236;ARGS_NAMES:pwd,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd"
+
+# Allow reference to `config.php` in refereer header when setting up WordPress
+SecRule REQUEST_HEADERS:referer "@rx ^https?://[a-zA-Z0-9-.]+/wp-admin/setup-config\.php(?:\?step=[0-9])?$" \
+    "id:9507411,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'wordpress-rule-exclusions-plugin/1.1.0',\
+    ctl:ruleRemoveTargetById=930121;REQUEST_HEADERS:referer"
 
 # WordPress installation: exclude admin password
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
     "id:9507420,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'wordpress-rule-exclusions-plugin/1.1.0',\
-    chain"
-    SecRule ARGS:step "@streq 2" \
-        "t:none,\
-        chain"
-        SecRule &ARGS:step "@eq 1" \
-            "t:none,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:admin_password,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:admin_password2,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text"
-
+    ctl:ruleRemoveTargetById=920273;ARGS:admin_email,\
+    ctl:ruleRemoveTargetById=920273;ARGS:Submit,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:admin_password,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:admin_password2,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text"
 
 #
 # [ User management ]

--- a/plugins/wordpress-rule-exclusions-before.conf
+++ b/plugins/wordpress-rule-exclusions-before.conf
@@ -766,14 +766,14 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/setup-config.php" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd"
 
 # Allow reference to `config.php` in refereer header when setting up WordPress
-SecRule REQUEST_HEADERS:referer "@rx ^https?://[a-zA-Z0-9-.]+/wp-admin/setup-config\.php(?:\?step=[0-9])?$" \
+SecRule REQUEST_HEADERS:Referer "@rx ^https?://[a-zA-Z0-9-.]+/wp-admin/setup-config\.php(?:\?step=[0-9])?$" \
     "id:9507411,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'wordpress-rule-exclusions-plugin/1.1.0',\
-    ctl:ruleRemoveTargetById=930121;REQUEST_HEADERS:referer"
+    ctl:ruleRemoveTargetById=930121;REQUEST_HEADERS:Referer"
 
 # WordPress installation: exclude admin password
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507410.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507410.yaml
@@ -1,0 +1,45 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Wordpress Rule Exclusions Plugin"
+rule_id: 9507410
+tests:
+  - test_id: 1
+    desc: Don't block `setup-config.php` as a config file
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          method: GET
+          version: "HTTP/1.1"
+          uri: /wp-admin/setup-config.php
+        output:
+          log:
+            no_expect_ids: [930130]
+  - test_id: 2
+    desc: Entering DB password for WordPress
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/x-www-form-urlencoded
+          port: 80
+          method: POST
+          version: "HTTP/1.1"
+          uri: /wp-admin/setup-config.php?step=2
+          data: "dbname=test&uname=test&pwd=%3Cscript%3E&dbhost=localhost&prefix=wp_&language=&submit=Submit"
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 930130
+              - 932260
+              - 932236
+              - 941110

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507411.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507411.yaml
@@ -10,11 +10,10 @@ tests:
       - input:
           dest_addr: 127.0.0.1
           headers:
-            Host: localhost
+            Host: example.com
             User-Agent: OWASP CRS test agent
             Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             Referer: https://example.com/wp-admin/setup-config.php?step=0
-            Host: example.com
           port: 80
           method: GET
           version: "HTTP/1.1"

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507411.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507411.yaml
@@ -1,0 +1,24 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Wordpress Rule Exclusions Plugin"
+rule_id: 9507411
+tests:
+  - test_id: 1
+    desc: Allow `setup-config.php` in referer header
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Referer: https://example.com/wp-admin/setup-config.php?step=0
+            Host: example.com
+          port: 80
+          method: GET
+          version: "HTTP/1.1"
+          uri: /favicon.ico
+        output:
+          log:
+            no_expect_ids: [930121]

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507411.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507411.yaml
@@ -17,7 +17,7 @@ tests:
           port: 80
           method: GET
           version: "HTTP/1.1"
-          uri: /favicon.ico
+          uri: /wp-admin/install.php
         output:
           log:
             no_expect_ids: [930121]

--- a/tests/regression/wordpress-rule-exclusions-plugin/9507420.yaml
+++ b/tests/regression/wordpress-rule-exclusions-plugin/9507420.yaml
@@ -1,0 +1,26 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Wordpress Rule Exclusions Plugin"
+rule_id: 9507420
+tests:
+  - test_id: 1
+    desc: Creating admin account in new WordPress installation
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/x-www-form-urlencoded
+          port: 80
+          method: POST
+          version: "HTTP/1.1"
+          uri: /wp-admin/install.php?step=2
+          data: "weblog_title=test&user_name=test&admin_password=%3Cscript%3E&admin_password2=%3Cscript%3E&pw_weak=on&admin_email=test%40example.com&Submit=Install+WordPress&language=en_US"
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 941110


### PR DESCRIPTION
Fixes new false positives when setting up a new WordPress installation. I removed the chained rules for these rules to simplify them, they shouldn't be needed since these endpoints are dedicated to WordPress setup and nothing else.